### PR TITLE
PreventActivationofOLE Fix

### DIFF
--- a/office/README.md
+++ b/office/README.md
@@ -71,6 +71,6 @@ After running through the import instructions below, the following policies and 
 2. Add a new PowerShell script, under *Devices > Windows > Powershell scripts*
     * *Name*: *OfficeMacroHardening-PreventActivationofOLE*
 3. Upload [OfficeMacroHardening-PreventActivationofOLE.ps1](scripts/OfficeMacroHardening-PreventActivationofOLE.ps1)
-    * *Run this script using the logged on credentials*: *No*
+    * *Run this script using the logged on credentials*: *Yes*
     * *Enforce script signature check*: *No*
     * *Run script in 64 bit PowerShell Host*: *No*


### PR DESCRIPTION
The script OfficeMacroHardening-PreventActivationofOLE.ps1 writes registry keys to Current User path, if ran under the system context (* *Run this script using the logged on credentials*: *No*) it will add those entries only for the system account. For the keys to be changed for the user the script also needs to run under user context.